### PR TITLE
/v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 cli:
 	go build -mod vendor -o bin/fetch cmd/fetch/main.go
+
+test:
+	./bin/fetch -verbose 1360695651

--- a/README.md
+++ b/README.md
@@ -110,18 +110,51 @@ Under the hood this tool uses a number of other packages for handling specific t
 
 ### Readers
 
-Readers exported by the following packages are available to the `fetch` tool:
+Readers exported by the following packages are available to the `fetch` tool, by default:
 
 * https://github.com/whosonfirst/go-reader
 * https://github.com/whosonfirst/go-reader-whosonfirst-data
 * https://github.com/whosonfirst/go-reader-http
-* https://github.com/whosonfirst/go-reader-github
 
 ### Writers
 
 Writers exported by the following packages are available to the `fetch` tool:
 
 * https://github.com/whosonfirst/go-writer
+
+### Alternate readers and writers
+
+As mentioned above the tool supports a limited set of default "readers" and "writers". If you need to add additional readers or writers you'll need to clone the code in [cmd/fetch/main.go](cmd/fetch/main.go) and add the relevant `import` statements.
+
+The "guts" of the `fetch` tool live in [app/fetch/fetch.go](app/fetch/fetch.go) which allows `cmd/fetch/main.go` to be very small in order to make add custom imports easy (or at least fast). 
+
+For example, this is what the code for a custom `fetch` tool which could also read from GitHub and write to a GeoParquet database would look like:
+
+```
+package main
+
+import (
+	"context"
+	"log"
+
+	_ "github.com/whosonfirst/go-reader-http"
+	_ "github.com/whosonfirst/go-reader-github"
+	_ "github.com/whosonfirst/go-reader-whosonfirst-data"
+	_ "github.com/whosonfirst/go-writer-geoparquet/v3"
+	
+	"github.com/whosonfirst/go-whosonfirst-fetch/app/fetch"
+)
+
+func main() {
+
+	ctx := context.Background()
+	err := fetch.Run(ctx)
+
+	if err != nil {
+		log.Fatalf("Failed to fetch records, %v", err)
+	}
+}
+```
 
 ## See also
 

--- a/app/fetch/fetch.go
+++ b/app/fetch/fetch.go
@@ -8,7 +8,7 @@ import (
 	"log/slog"
 
 	"github.com/whosonfirst/go-reader"
-	"github.com/whosonfirst/go-whosonfirst-fetch"
+	"github.com/whosonfirst/go-whosonfirst-fetch/v2"
 	"github.com/whosonfirst/go-writer/v3"
 )
 

--- a/app/fetch/fetch.go
+++ b/app/fetch/fetch.go
@@ -1,0 +1,78 @@
+// fetch is a command line tool to retrieve one or more Who's on First records and, optionally, their ancestors.
+package fetch
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+
+	"github.com/whosonfirst/go-reader"
+	"github.com/whosonfirst/go-whosonfirst-fetch"
+	"github.com/whosonfirst/go-writer/v3"
+)
+
+func Run(ctx context.Context) error {
+	fs := DefaultFlagSet()
+	return RunWithFlagSet(ctx, fs)
+}
+
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
+
+	opts, err := DeriveRunOptionsFromFlagSet(fs)
+
+	if err != nil {
+		return err
+	}
+
+	return RunWithOptions(ctx, opts)
+}
+
+func RunWithOptions(ctx context.Context, opts *RunOptions) error {
+
+	if opts.Verbose {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+		slog.Debug("Verbose logging enabled")
+	}
+
+	r, err := reader.NewReader(ctx, opts.ReaderURI)
+
+	if err != nil {
+		return fmt.Errorf("Failed to create reader, %w", err)
+	}
+
+	wr, err := writer.NewWriter(ctx, opts.WriterURI)
+
+	if err != nil {
+		return fmt.Errorf("Failed to create writer, %w", err)
+	}
+
+	fetcher_opts, err := fetch.DefaultOptions()
+
+	if err != nil {
+		return fmt.Errorf("Failed to create fetch options, %w", err)
+	}
+
+	fetcher_opts.Retries = opts.Retries
+	fetcher_opts.MaxClients = opts.MaxClients
+
+	fetcher, err := fetch.NewFetcher(ctx, r, wr, fetcher_opts)
+
+	if err != nil {
+		return fmt.Errorf("Failed to create fetcher, %w", err)
+	}
+
+	slog.Debug("Fetch items", "count", len(opts.IDs))
+
+	fetched_ids, err := fetcher.FetchIDs(ctx, opts.IDs, opts.BelongsTo...)
+
+	if err != nil {
+		return fmt.Errorf("Failed to fetch IDs, %w", err)
+	}
+
+	for _, id := range fetched_ids {
+		fmt.Println(id)
+	}
+
+	return nil
+}

--- a/app/fetch/flags.go
+++ b/app/fetch/flags.go
@@ -1,0 +1,44 @@
+package fetch
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mitchellh/go-wordwrap"
+	"github.com/sfomuseum/go-flags/flagset"
+	"github.com/sfomuseum/go-flags/multi"
+)
+
+var reader_uri string
+var writer_uri string
+var retries int
+var max_clients int
+var belongs_to multi.MultiString
+var verbose bool
+
+func DefaultFlagSet() *flag.FlagSet {
+
+	fs := flagset.NewFlagSet("fetch")
+
+	fs.StringVar(&reader_uri, "reader-uri", "whosonfirst-data://", "A valid whosonfirst/go-reader URI.")
+	fs.StringVar(&writer_uri, "writer-uri", "stdout://", "A valid whosonfirst/go-writer URI.")
+	fs.IntVar(&retries, "retries", 3, "The maximum number of attempts to try fetching a record.")
+	fs.IntVar(&max_clients, "max-clients", 10, "The maximum number of concurrent requests for multiple Who's On First records.")
+
+	fs.Var(&belongs_to, "belongs-to", "One or more placetypes that a given ID may belong to to also fetch. You may also pass 'all' as a short-hand to fetch the entire hierarchy for a place.")
+
+	fs.BoolVar(&verbose, "verbose", false, "Enable verbose (debug) logging.")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Fetch one or more Who's on First records and, optionally, their ancestors.\n\n")
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "  %s [options] [path1 path2 ... pathN]\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		fs.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\nNotes:\n\n")
+		fmt.Fprintf(os.Stderr, wordwrap.WrapString("pathN may be any valid Who's On First ID or URI that can be parsed by the go-whosonfirst-uri package.\n\n", 80))
+	}
+
+	return fs
+}

--- a/app/fetch/options.go
+++ b/app/fetch/options.go
@@ -1,0 +1,56 @@
+package fetch
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/sfomuseum/go-flags/flagset"
+	"github.com/whosonfirst/go-whosonfirst-uri"
+)
+
+type RunOptions struct {
+	ReaderURI  string
+	WriterURI  string
+	Retries    int
+	MaxClients int
+	BelongsTo  []string
+	IDs        []int64
+	Verbose    bool
+}
+
+func DeriveRunOptionsFromFlagSet(fs *flag.FlagSet) (*RunOptions, error) {
+
+	flagset.Parse(fs)
+
+	err := flagset.SetFlagsFromEnvVarsWithFeedback(fs, "OFFLINE", false)
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to set flags from environment variables, %w", err)
+	}
+
+	uris := fs.Args()
+	ids := make([]int64, 0)
+
+	for _, raw := range uris {
+
+		id, _, err := uri.ParseURI(raw)
+
+		if err != nil {
+			return nil, fmt.Errorf("Unable to parse URI '%s', %w", raw, err)
+		}
+
+		ids = append(ids, id)
+	}
+
+	opts := &RunOptions{
+		ReaderURI:  reader_uri,
+		WriterURI:  writer_uri,
+		Retries:    retries,
+		MaxClients: max_clients,
+		BelongsTo:  belongs_to,
+		IDs:        ids,
+		Verbose:    verbose,
+	}
+
+	return opts, nil
+}

--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -3,95 +3,20 @@ package main
 
 import (
 	"context"
-	"flag"
-	"fmt"
 	"log"
-	"os"
 
 	_ "github.com/whosonfirst/go-reader-http"
 	_ "github.com/whosonfirst/go-reader-whosonfirst-data"
-	
-	"github.com/mitchellh/go-wordwrap"
-	"github.com/sfomuseum/go-flags/multi"
-	"github.com/whosonfirst/go-reader"
-	"github.com/whosonfirst/go-whosonfirst-fetch"
-	"github.com/whosonfirst/go-whosonfirst-uri"
-	"github.com/whosonfirst/go-writer/v3"	
+
+	"github.com/whosonfirst/go-whosonfirst-fetch/app/fetch"
 )
 
 func main() {
 
-	reader_uri := flag.String("reader-uri", "whosonfirst-data://", "A valid whosonfirst/go-reader URI.")
-	writer_uri := flag.String("writer-uri", "null://", "A valid whosonfirst/go-writer URI.")
-	retries := flag.Int("retries", 3, "The maximum number of attempts to try fetching a record.")
-	max_clients := flag.Int("max-clients", 10, "The maximum number of concurrent requests for multiple Who's On First records.")
-
-	var belongs_to multi.MultiString
-	flag.Var(&belongs_to, "belongs-to", "One or more placetypes that a given ID may belong to to also fetch. You may also pass 'all' as a short-hand to fetch the entire hierarchy for a place.")
-
-	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Fetch one or more Who's on First records and, optionally, their ancestors.\n\n")
-		fmt.Fprintf(os.Stderr, "Usage:\n")
-		fmt.Fprintf(os.Stderr, "  %s [options] [path1 path2 ... pathN]\n\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "Options:\n")
-		flag.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "\nNotes:\n\n")
-		fmt.Fprintf(os.Stderr, wordwrap.WrapString("pathN may be any valid Who's On First ID or URI that can be parsed by the go-whosonfirst-uri package.\n\n", 80))
-	}
-
-	flag.Parse()
-
 	ctx := context.Background()
-
-	r, err := reader.NewReader(ctx, *reader_uri)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	wr, err := writer.NewWriter(ctx, *writer_uri)
+	err := fetch.Run(ctx)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to fetch records, %v", err)
 	}
-
-	fetcher_opts, err := fetch.DefaultOptions()
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fetcher_opts.Retries = *retries
-	fetcher_opts.MaxClients = *max_clients
-
-	fetcher, err := fetch.NewFetcher(ctx, r, wr, fetcher_opts)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	uris := flag.Args()
-	ids := make([]int64, 0)
-
-	for _, raw := range uris {
-
-		id, _, err := uri.ParseURI(raw)
-
-		if err != nil {
-			log.Fatalf("Unable to parse URI '%s', %v", raw, err)
-		}
-
-		ids = append(ids, id)
-	}
-
-	fetched_ids, err := fetcher.FetchIDs(ctx, ids, belongs_to...)
-
-	if err != nil {
-		log.Fatalf("Failed to fetch IDs, %v", err)
-	}
-
-	for _, id := range fetched_ids {
-		fmt.Println(id)
-	}
-
 }

--- a/cmd/fetch/main.go
+++ b/cmd/fetch/main.go
@@ -8,7 +8,7 @@ import (
 	_ "github.com/whosonfirst/go-reader-http"
 	_ "github.com/whosonfirst/go-reader-whosonfirst-data"
 
-	"github.com/whosonfirst/go-whosonfirst-fetch/app/fetch"
+	"github.com/whosonfirst/go-whosonfirst-fetch/v2/app/fetch"
 )
 
 func main() {

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -4,22 +4,22 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"testing"
 
 	_ "github.com/whosonfirst/go-reader-whosonfirst-data"
-	
+
 	"github.com/whosonfirst/go-reader"
 	"github.com/whosonfirst/go-whosonfirst-uri"
-	"github.com/whosonfirst/go-writer/v3"	
+	"github.com/whosonfirst/go-writer/v3"
 )
 
 func TestFetch(t *testing.T) {
 
 	slog.SetLogLoggerLevel(slog.LevelDebug)
-	
+
 	ctx := context.Background()
 
 	tmpdir, err := ioutil.TempDir("", "fetch")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/whosonfirst/go-whosonfirst-fetch
 
-go 1.22.1
+go 1.23.0
 
 toolchain go1.24.2
 
@@ -9,7 +9,6 @@ require (
 	github.com/sfomuseum/go-flags v0.10.0
 	github.com/whosonfirst/go-ioutil v1.0.2
 	github.com/whosonfirst/go-reader v1.1.0
-	github.com/whosonfirst/go-reader-http v0.3.2
 	github.com/whosonfirst/go-reader-whosonfirst-data v1.4.2
 	github.com/whosonfirst/go-whosonfirst-feature v0.0.28
 	github.com/whosonfirst/go-whosonfirst-uri v1.3.0
@@ -63,6 +62,7 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/whosonfirst/go-reader-github v0.6.11 // indirect
+	github.com/whosonfirst/go-reader-http v0.3.2 // indirect
 	github.com/whosonfirst/go-whosonfirst-findingaid/v2 v2.8.7 // indirect
 	github.com/whosonfirst/go-whosonfirst-flags v0.5.1 // indirect
 	github.com/whosonfirst/go-whosonfirst-sources v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/whosonfirst/go-whosonfirst-fetch
+module github.com/whosonfirst/go-whosonfirst-fetch/v2
 
 go 1.23.0
 
@@ -9,6 +9,7 @@ require (
 	github.com/sfomuseum/go-flags v0.10.0
 	github.com/whosonfirst/go-ioutil v1.0.2
 	github.com/whosonfirst/go-reader v1.1.0
+	github.com/whosonfirst/go-reader-http v0.3.2
 	github.com/whosonfirst/go-reader-whosonfirst-data v1.4.2
 	github.com/whosonfirst/go-whosonfirst-feature v0.0.28
 	github.com/whosonfirst/go-whosonfirst-uri v1.3.0
@@ -62,7 +63,6 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/whosonfirst/go-reader-github v0.6.11 // indirect
-	github.com/whosonfirst/go-reader-http v0.3.2 // indirect
 	github.com/whosonfirst/go-whosonfirst-findingaid/v2 v2.8.7 // indirect
 	github.com/whosonfirst/go-whosonfirst-flags v0.5.1 // indirect
 	github.com/whosonfirst/go-whosonfirst-sources v0.1.0 // indirect

--- a/vendor/github.com/sfomuseum/go-flags/flagset/flagset.go
+++ b/vendor/github.com/sfomuseum/go-flags/flagset/flagset.go
@@ -1,0 +1,85 @@
+// package flagset provides methods for working with `flag.FlagSet` instances.
+package flagset
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+// Parse command line arguments with a flag.FlagSet instance.
+func Parse(fs *flag.FlagSet) {
+
+	args := os.Args[1:]
+
+	if len(args) > 0 && args[0] == "-h" {
+		fs.Usage()
+		os.Exit(0)
+	}
+
+	fs.Parse(args)
+}
+
+// Assign values to a flag.FlagSet instance from matching environment variables.
+func SetFlagsFromEnvVars(fs *flag.FlagSet, prefix string) error {
+	return SetFlagsFromEnvVarsWithFeedback(fs, prefix, false)
+}
+
+// Assign values to a flag.FlagSet instance from matching environment variables, optionally logging progress and other feedback.
+func SetFlagsFromEnvVarsWithFeedback(fs *flag.FlagSet, prefix string, feedback bool) error {
+
+	fs.VisitAll(func(fl *flag.Flag) {
+
+		name := fl.Name
+		env := FlagNameToEnvVar(prefix, name)
+
+		val, ok := os.LookupEnv(env)
+
+		if ok {
+
+			if feedback {
+				log.Printf("set -%s flag from %s environment variable\n", name, env)
+			}
+
+			fs.Set(name, val)
+		}
+	})
+
+	return nil
+}
+
+// Create a new flag.FlagSet instance.
+func NewFlagSet(name string) *flag.FlagSet {
+
+	fs := flag.NewFlagSet(name, flag.ExitOnError)
+
+	fs.Usage = func() {
+		fs.PrintDefaults()
+	}
+
+	return fs
+}
+
+// FlagNameToEnvVar formats 'name' and 'prefix' in to an environment variable name, used to lookup
+// a value.
+func FlagNameToEnvVar(prefix string, name string) string {
+
+	prefix = normalizeEnvVar(prefix)
+	name = normalizeEnvVar(name)
+
+	return fmt.Sprintf("%s_%s", prefix, name)
+
+}
+
+// normalizeEnvVar normalizes a flag name in to its corresponding environment variable name.
+func normalizeEnvVar(raw string) string {
+
+	new := raw
+
+	new = strings.ToUpper(new)
+	new = strings.Replace(new, "-", "_", -1)
+
+	return new
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -243,6 +243,7 @@ github.com/paulmach/orb
 github.com/sfomuseum/go-edtf
 # github.com/sfomuseum/go-flags v0.10.0
 ## explicit; go 1.16
+github.com/sfomuseum/go-flags/flagset
 github.com/sfomuseum/go-flags/multi
 # github.com/sfomuseum/runtimevar v1.2.0
 ## explicit; go 1.18


### PR DESCRIPTION
* Replace `fetch.Options.Logger` with plain-vanilla `log/slog` methods
* Move the guts of `cmd/fetch` in to `app/fetch`
* Improved error reporting
* Improved docs
* This release is NOT backwards compatible